### PR TITLE
Support python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
         uv run poe lint
     - name: Tests
       run: |
-        if python --version | grep -q 'Python 3.12' ; then
+        if python --version | grep -q 'Python 3.13' ; then
           uv run poe test
         fi
     - name: Codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "listdiff"
-version = "1.0.2"
+version = "1.0.3"
 description = "Diff 2 python lists using a given key"
 maintainers = [
 	{ name = "Rehan Khwaja", email = "rehan@khwaja.name" }
@@ -14,7 +14,8 @@ classifiers = [
 	"Programming Language :: Python :: 3.9",
 	"Programming Language :: Python :: 3.10",
 	"Programming Language :: Python :: 3.11",
-	"Programming Language :: Python :: 3.12"
+	"Programming Language :: Python :: 3.12",
+	"Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.8"
 dependencies = []


### PR DESCRIPTION
[Release schedule](https://peps.python.org/pep-0719/) (10/7 for final release)

[Prereleases](https://www.python.org/download/pre-releases/)

[Github supported versions](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json)